### PR TITLE
feat: reuse tcp connection

### DIFF
--- a/easywebdav/client.py
+++ b/easywebdav/client.py
@@ -120,7 +120,7 @@ class Client(object):
 
     def mkdir(self, path, safe=False):
         expected_codes = 201 if not safe else (201, 301, 405)
-        self._send('MKCOL', path, expected_codes)
+        self._send('MKCOL', path, expected_codes).content
 
     def mkdirs(self, path):
         dirs = [d for d in path.split('/') if d]
@@ -144,10 +144,10 @@ class Client(object):
     def rmdir(self, path, safe=False):
         path = str(path).rstrip('/') + '/'
         expected_codes = 204 if not safe else (204, 404)
-        self._send('DELETE', path, expected_codes)
+        self._send('DELETE', path, expected_codes).content
 
     def delete(self, path):
-        self._send('DELETE', path, 204)
+        self._send('DELETE', path, 204).content
 
     def upload(self, local_path_or_fileobj, remote_path):
         if isinstance(local_path_or_fileobj, basestring):
@@ -157,7 +157,7 @@ class Client(object):
             self._upload(local_path_or_fileobj, remote_path)
 
     def _upload(self, fileobj, remote_path):
-        self._send('PUT', remote_path, (200, 201, 204), data=fileobj)
+        self._send('PUT', remote_path, (200, 201, 204), data=fileobj).content
 
     def download(self, remote_path, local_path_or_fileobj):
         response = self._send('GET', remote_path, 200, stream=True)
@@ -185,4 +185,5 @@ class Client(object):
 
     def exists(self, remote_path):
         response = self._send('HEAD', remote_path, (200, 301, 404))
+        response.content
         return True if response.status_code != 404 else False


### PR DESCRIPTION
As per the documentation of `requests`, a connection won't be released
until `content` is read from `Response`. This commit adds dummy reads
at proper positions.