### PR TITLE
MOVE: Accept 201 & 204 status codes

### DIFF
--- a/easywebdav/client.py
+++ b/easywebdav/client.py
@@ -162,7 +162,7 @@ class Client(object):
         self._send('DELETE', path, (200, 204)).content
 
     def move(self, path, new_path):
-        self._send('MOVE', path, 204,headers={"Destination":new_path,'Connection':'TE','TE':'trailers','Overwrite':'T'}).content
+        self._send('MOVE', path, (201, 204),headers={"Destination":new_path,'Connection':'TE','TE':'trailers','Overwrite':'T'}).content
 
     def upload(self, local_path_or_fileobj, remote_path, headers=None):
         if isinstance(local_path_or_fileobj, basestring):


### PR DESCRIPTION
Conforming to the RFC 4918 9.9.4
(https://tools.ietf.org/html/rfc4918#section-9.9.4), the move command
return either 201 or 204.

Credits to github/aagostini

Signed-off-by: Frank Villaro-Dixon <frank.villaro@infomaniak.com>